### PR TITLE
Allow `Z`-related tests to fail

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+DATE=$(date "+%Y-%m-%d")
+[[ "$RUNNER_OS" == 'Windows' ]] && IS_WIN=true || IS_WIN=false
+BIN=bin
+EXT=""
+$IS_WIN && EXT=".exe"
+mkdir -p "$BIN"
+
+is_exe() { [[ -x "$1/$2$EXT" ]] || command -v "$2" > /dev/null 2>&1; }
+
+install_solvers() {
+  (cd $BIN && curl -o bins.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/$SOLVER_PKG_VERSION/$BUILD_TARGET_OS-$BUILD_TARGET_ARCH-bin.zip" && unzip -o bins.zip && rm bins.zip)
+  cp $BIN/yices_smt2$EXT $BIN/yices-smt2$EXT
+  chmod +x $BIN/*
+}
+
+install_system_deps() {
+  install_solvers
+  # wait
+  export PATH=$PWD/$BIN:$PATH
+  echo "$PWD/$BIN" >> $GITHUB_PATH
+  is_exe "$BIN" z3
+}
+
+COMMAND="$1"
+shift
+
+"$COMMAND" "$@"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,7 +33,7 @@ jobs:
         BUILD_TARGET_OS: ${{ matrix.os }}
         BUILD_TARGET_ARCH: ${{ runner.arch }}
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    
+
     - name: Install prereqs.
       run: |
         sudo apt-get update
@@ -44,8 +44,8 @@ jobs:
     - name: Install dependencies
       run: |
         cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
+        cabal build --only-dependencies --enable-tests
     - name: Build
-      run: cabal build --enable-tests --enable-benchmarks all
+      run: cabal build --enable-tests all
     - name: Run tests
       run: cabal test all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,20 +9,27 @@ on:
 permissions:
   contents: read
 
+env:
+  SOLVER_PKG_VERSION: "snapshot-20240212"
+
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - name: Install prereqs.
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y curl
+    - name: Install system dependencies
+      shell: bash
+      run: .github/ci.sh install_system_deps
+      env:
+        BUILD_TARGET_OS: ${{ matrix.os }}
+        BUILD_TARGET_ARCH: ${{ runner.arch }}
 
     - uses: haskell/actions/setup@v1
       with:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,6 +18,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
+        ghc: ["9.4.7"]
+        cabal: ["3.6.2"]
 
     steps:
     - uses: actions/checkout@v3
@@ -33,8 +35,8 @@ jobs:
 
     - uses: haskell/actions/setup@v1
       with:
-        ghc-version: '9.4.7'
-        cabal-version: '3.6.2'
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
 
     - name: Restore cabal store cache
       uses: actions/cache/restore@v3

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,17 +38,15 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - name: Restore cabal store cache
-      uses: actions/cache/restore@v3
-      env:
-        cache-name: cache-cabal
+    - uses: actions/cache/restore@v3
+      name: Restore cabal store cache
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
+        key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+          ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 
     - name: Install dependencies
       run: |
@@ -59,11 +57,11 @@ jobs:
     - name: Run tests
       run: cabal test all
 
-    - name: Save cabal store cache
-      uses: actions/cache/save@v3
+    - uses: actions/cache/save@v3
+      name: Save cabal store cache
       if: always()
-      env:
-        cache-name: cache-cabal
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
+        key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,8 +36,8 @@ jobs:
         ghc-version: '9.4.7'
         cabal-version: '3.6.2'
 
-    - name: Cache
-      uses: actions/cache@v3
+    - name: Restore cabal store cache
+      uses: actions/cache/restore@v3
       env:
         cache-name: cache-cabal
       with:
@@ -56,3 +56,12 @@ jobs:
       run: cabal build --enable-tests all
     - name: Run tests
       run: cabal test all
+
+    - name: Save cabal store cache
+      uses: actions/cache/save@v3
+      if: always()
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        ghc: ["9.4.7"]
-        cabal: ["3.6.2"]
+        ghc: ["9.4.8"]
+        cabal: ["3.10.2.0"]
 
     steps:
     - uses: actions/checkout@v3

--- a/cryptol-compiler.cabal
+++ b/cryptol-compiler.cabal
@@ -148,6 +148,7 @@ test-suite cryptol-compiler-test
         base,
         cryptol-compiler,
         tasty,
+        tasty-expected-failure,
         tasty-golden,
         process,
         temporary,


### PR DESCRIPTION
Currently, the test cases involves values of type `Z` do not work (see https://github.com/GaloisInc/cryptol-compiler/issues/31), so we mark them as expected to fail in the interest of making CI work.

Fixes https://github.com/GaloisInc/cryptol-compiler/issues/30.